### PR TITLE
correct dirname error and inequality warning

### DIFF
--- a/aux_functions.py
+++ b/aux_functions.py
@@ -256,7 +256,7 @@ Given a kitti dir, and a type ('train'/'val'), return a list of drives and a map
 """
 def get_train_val_drive_list(src_path, dir_type):
     assert (dir_type in train_and_val())
-    dirname = src_path + '/' + get_train_val_type_dirs()[0] + '/' + dir_type  # takes data_depth_annotated
+    dirname = src_path + get_train_val_type_dirs()[0] + '/' + dir_type  # takes data_depth_annotated
     drives = os.listdir(dirname)
     img_count = {}
     for drive in drives:
@@ -445,6 +445,7 @@ def copypath(src, dest, overwrite_dest_dir=False):
             sys.exit('FAILED copytree. Exiting.')
     else:
         try:
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
             shutil.copyfile(src, dest)
         except:
             sys.exit('FAILED copyfile. Exiting.')

--- a/main.py
+++ b/main.py
@@ -58,7 +58,7 @@ def predict(curr_args, loader, curr_model):
         pred = curr_model(batch_data)
         pred_out_dir = curr_args.pred_dir
 
-        if pred_out_dir is not '':
+        if pred_out_dir != '':
             pred1 = pred.cpu().detach().numpy()[:, 0, :, :]
             for im_idx, pred_im in enumerate(pred1):
                 data_folder1 = os.path.abspath(curr_args.data_folder)


### PR DESCRIPTION
Small error that was preventing training for me. 

`src_path + '/'` is `'../data//'` which is not a valid directory. Corrected to `'../data/'`.

Corrected `pred_out_dir is not '':` to `pred_out_dir != '':` which is probably the intended line. 
